### PR TITLE
Align Responses API payload with input_text format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export interface Env {
   WEBHOOK_SECRET?: string; // configured via wrangler vars
   BOT_KV: KVNamespace;
   WEBHOOK_PATH?: string;
+  OPENAI_API_KEY: string;
+  OPENAI_MODEL?: string;
 }
 
 export default {
@@ -40,8 +42,73 @@ export default {
       const text = message?.text;
 
       if (chatId && typeof text === "string") {
+        if (!env.OPENAI_API_KEY) {
+          console.error("Missing OPENAI_API_KEY binding");
+          return new Response("missing openai api key", { status: 500 });
+        }
+
+        const model = env.OPENAI_MODEL || "gpt-5-mini";
+
+        const openaiRequestBody = {
+          model,
+          input: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "input_text",
+                  text: `You are a helpful AI assistant replying in the same language the user used.\n\nUser message: ${text}`,
+                },
+              ],
+            },
+          ],
+          max_output_tokens: 800,
+        };
+
+        let assistantReply = "";
+
+        try {
+          const openaiResponse = await fetch("https://api.openai.com/v1/responses", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              Authorization: `Bearer ${env.OPENAI_API_KEY}`,
+            },
+            body: JSON.stringify(openaiRequestBody),
+          });
+
+          if (!openaiResponse.ok) {
+            const errorText = await openaiResponse.text();
+            console.error(
+              "OpenAI API request failed",
+              openaiResponse.status,
+              errorText,
+            );
+            assistantReply =
+              "متاسفم، در حال حاضر نمی‌توانم پاسخ بدهم. لطفاً بعداً دوباره تلاش کنید.";
+          } else {
+            const data = await openaiResponse.json();
+            const responseText =
+              data?.output_text ||
+              data?.output?.flatMap((item: any) => item?.content || [])
+                ?.find((part: any) => part?.type === "output_text")?.text ||
+              data?.output?.[0]?.content?.find(
+                (part: any) => part?.type === "output_text",
+              )?.text;
+
+            assistantReply =
+              typeof responseText === "string" && responseText.trim().length > 0
+                ? responseText.trim()
+                : "پاسخی از مدل دریافت نشد.";
+          }
+        } catch (error) {
+          console.error("Failed to call OpenAI API", error);
+          assistantReply =
+            "خطایی در برقراری ارتباط با سرویس هوش مصنوعی رخ داد.";
+        }
+
         const telegramApiUrl = `https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`;
-        const payload = { chat_id: chatId, text };
+        const payload = { chat_id: chatId, text: assistantReply };
 
         try {
           const response = await fetch(telegramApiUrl, {


### PR DESCRIPTION
## Summary
- collapse the OpenAI Responses request body into a single user turn with `input_text` content so the schema matches current requirements
- tighten output parsing to look specifically for `output_text` entries before falling back to aggregated text

## Testing
- npm run deploy -- --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68d515a202e08330be3fcd0549dc0d23