### PR TITLE
Update name in Wrangler configuration file to match deployed Worker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,22 @@ export default {
           const payload = {
             chat_id: chatId,
             text: answerText,
+
+          const replyText =
+            typeof openAiResult?.answer === "string" && openAiResult.answer.trim().length > 0
+              ? openAiResult.answer.trim()
+              : "پاسخی از مدل دریافت نشد.";
+
+          const payload = {
+            chat_id: chatId,
+            text: replyText,
+
+          const formattedResult = JSON.stringify(openAiResult, null, 2);
+
+          const payload = {
+            chat_id: chatId,
+            text: formattedResult,
+
           };
 
           const response = await fetch(telegramApiUrl, {


### PR DESCRIPTION
The Worker name in your Wrangler configuration file does not match the name of the deployed Worker in the Cloudflare Dashboard.
		Cloudflare automatically generated this PR to resolve the mismatch and avoid inconsistencies between environments. For more information, see: https://developers.cloudflare.com/workers/ci-cd/builds/troubleshoot/#workers-name-requirement