### PR TITLE
Send OpenAI responses to Telegram users

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,21 +125,13 @@ export default {
         try {
           const openAiResult = await invokeOpenAI(text);
 
-          const replyText =
-            typeof openAiResult?.answer === "string" && openAiResult.answer.trim().length > 0
-              ? openAiResult.answer.trim()
-              : "پاسخی از مدل دریافت نشد.";
-
-          const payload = {
-            chat_id: chatId,
-            text: replyText,
-
           const formattedResult = JSON.stringify(openAiResult, null, 2);
+          const trimmedResult =
+            formattedResult.length > 4000 ? `${formattedResult.slice(0, 3997)}...` : formattedResult;
 
           const payload = {
             chat_id: chatId,
-            text: formattedResult,
-
+            text: trimmedResult,
           };
 
           const response = await fetch(telegramApiUrl, {


### PR DESCRIPTION
## Summary
- send Telegram replies using the aggregated OpenAI response payload
- trim long responses to stay within Telegram message limits

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d554676f6083309721bac73c3bf5c5