### PR TITLE
Add TypeScript test script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250920.0",
+        "typescript": "^5.9.2",
         "wrangler": "^4.38.0"
       }
     },
@@ -1407,6 +1408,20 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Minimal Cloudflare Worker Telegram bot skeleton",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "test": "tsc --noEmit"
   },
   "keywords": [
     "cloudflare",
@@ -17,6 +18,7 @@
   "type": "module",
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250920.0",
+    "typescript": "^5.9.2",
     "wrangler": "^4.38.0"
   }
 }


### PR DESCRIPTION
## Summary
- add an npm test script that runs the TypeScript compiler in no-emit mode
- include the TypeScript dev dependency in the lockfile

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d805eb4cf08330b276bfa9e50775ef